### PR TITLE
feat(audit): add function for emitting 'audit' event

### DIFF
--- a/imt-proto.d.ts
+++ b/imt-proto.d.ts
@@ -129,6 +129,7 @@ declare namespace imtProto {
 
         initialize(done: (err?: Error) => void): void;
         finalize(done: (err?: Error) => void): void;
+        audit(payload): void;
         commit(done: (err: Error | null, report: any[]) => void): void;
         warn(...args): void;
         debug(...args): void;

--- a/lib-es5/base.js
+++ b/lib-es5/base.js
@@ -47,6 +47,10 @@ global.IMTBase = function(supr) {
 		throw new Error("Must override a superclass method 'addSharedTransaction'.");
 	}
 
+	IMTBase.prototype.audit = function audit(payload) {
+		this.emit('audit', payload);
+	}
+
 	IMTBase.prototype.commit = function commit(done) {
 		if ("function" === typeof done) done(null, null);
 	}

--- a/lib-es6/base.js
+++ b/lib-es6/base.js
@@ -64,6 +64,16 @@ global.IMTBase = class IMTBase extends EventEmitter {
 	}
 
 	/**
+	 * Emit audit message to Engine log. The arguments provided are intended to be shown in the Audit Trail for Module Execution Logs
+	 *
+	 * @param {object} payload Payload to be added to the Module Execution Log
+	 */
+
+	audit(payload) {
+		this.emit('audit', payload);
+	}
+
+	/**
 	 * Commit all operations.
 	 * 
 	 * @callback done Callback to call when operations are done.


### PR DESCRIPTION
#### Ticket URL: https://celonis.atlassian.net/browse/EMA-2358

#### Description
Adds native support for the `audit` event which will be emitted by modules in order to pass audit payloads to the engine.


#### Relevant Links
- https://github.com/integromat/imt-engine/pull/90
- https://github.com/integromat/imt-app-runtime/pull/9

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have fully documented the new code (if applicable)