### PR TITLE
fix: ES5 compatibility fixes

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { Common, Data } from './base';
+import { CommonData, ModuleData } from './base';
 import { DoneCallback } from './types';
 
 export type Scope = string[];
@@ -12,9 +12,9 @@ export type DoneWithUrlCallback = (err?: Error | null, url?: string) => void;
  * @property common - Collection of common parameters. Read only.
  * @property data - Collection of config parameters.
  */
-export abstract class IMTAccount {
-  public common: Common | null;
-  public data: Data | null;
+export class IMTAccount {
+  public common: CommonData | null;
+  public data: ModuleData | null;
 
   constructor() {
     this.common = null;
@@ -68,7 +68,7 @@ export abstract class IMTAccount {
 Base class for all OAuth Accounts.
 */
 
-export abstract class IMTOAuthAccount extends IMTAccount {
+export class IMTOAuthAccount extends IMTAccount {
   private id?: string | null;
 
   /**

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,7 +1,7 @@
 import { IMTBase, ModuleType } from './base';
 import { Bundle, DoneWithInfoCallback } from './types';
 
-export abstract class IMTAction extends IMTBase {
+export class IMTAction extends IMTBase {
   public readonly type = ModuleType.ACTION;
 
   /**
@@ -12,17 +12,21 @@ export abstract class IMTAction extends IMTBase {
    *     @param {Error} err Error on error, otherwise null.
    */
 
-  abstract write(bundle: Bundle, done: DoneWithInfoCallback): void;
+  write(bundle: Bundle, done: DoneWithInfoCallback): void {
+    void bundle;
+    void done;
+    throw new Error("Must override a superclass method 'write'.");
+  }
 }
 
 /**
  * Base Gateway Action.
  */
 
-export abstract class IMTGatewayAction extends IMTAction {}
+export class IMTGatewayAction extends IMTAction {}
 
 /**
  * Base Gateway Responder.
  */
 
-export abstract class IMTGatewayResponder extends IMTAction {}
+export class IMTGatewayResponder extends IMTAction {}

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -5,8 +5,8 @@ import { IMTTransformer } from './transformer';
  * Base class for all Aggregators.
  */
 
-export abstract class IMTAggregator extends IMTTransformer {
-  protected constructor() {
+export class IMTAggregator extends IMTTransformer {
+  constructor() {
     super(ModuleType.AGGREGATOR);
   }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -3,17 +3,17 @@ import { Warning } from './warning';
 import { EventEmitter } from 'events';
 import { DoneCallback, DoneWithReportCallback } from './types';
 
-export type Common = Record<string, any>;
+export type CommonData = Record<string, any>;
 
-export type Data = Record<string, any>;
+export type ModuleData = Record<string, any>;
 
 export type Parameters = {
   host: string;
 } & Record<string, any>;
 
-export type Scenario = Record<string, any>;
+export type ScenarioData = Record<string, any>;
 
-export type Environment = Record<string, any>;
+export type EnvironmentData = Record<string, any>;
 
 export enum ModuleType {
   NONE = 0,
@@ -43,8 +43,8 @@ export enum ModuleType {
  * @event log - Dispatched when message is about to be printed to info log.
  * @event warn - Dispatched when message is about to be printed to warning log.
  */
-export abstract class IMTBase extends EventEmitter {
-  public abstract readonly type: ModuleType;
+export class IMTBase extends EventEmitter {
+  public readonly type: ModuleType = ModuleType.NONE;
 
   public static readonly MODULETYPE_NONE = ModuleType.NONE;
   public static readonly MODULETYPE_TRIGGER = ModuleType.TRIGGER;
@@ -59,11 +59,11 @@ export abstract class IMTBase extends EventEmitter {
   public static readonly MODULETYPE_HITL = ModuleType.HITL;
   public static readonly MODULETYPE_PAUSER = ModuleType.PAUSER;
 
-  public common: Common | null = null;
-  public data: Data | null = null;
+  public common: CommonData | null = null;
+  public data: ModuleData | null = null;
   public parameters: Parameters | null = null;
-  public scenario: Scenario | null = null;
-  public environment: Environment | null = null;
+  public scenario: ScenarioData | null = null;
+  public environment: EnvironmentData | null = null;
 
   /**
    * Initializes the module. Function that overrides should always call super.

--- a/src/converger.ts
+++ b/src/converger.ts
@@ -4,6 +4,6 @@ import { IMTBase, ModuleType } from './base';
  * Base class for all Convergers.
  */
 
-export abstract class IMTConverger extends IMTBase {
+export class IMTConverger extends IMTBase {
   public readonly type = ModuleType.CONVERGER;
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -44,7 +44,8 @@ export class UnknownError extends Error {
       this.message = err;
     }
 
-    this.name = this.constructor.name;
+    this.name = 'UnknownError';
+    Object.setPrototypeOf(this, UnknownError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -67,7 +68,8 @@ export class RuntimeError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'RuntimeError';
+    Object.setPrototypeOf(this, RuntimeError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -86,7 +88,8 @@ export class DataError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'DataError';
+    Object.setPrototypeOf(this, DataError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -105,7 +108,8 @@ export class InconsistencyError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'InconsistencyError';
+    Object.setPrototypeOf(this, InconsistencyError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -130,7 +134,8 @@ export class RateLimitError extends Error {
   constructor(message: string, delay: number) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'RateLimitError';
+    Object.setPrototypeOf(this, RateLimitError.prototype);
     this.delay = delay;
 
     Error.captureStackTrace(this, this.constructor);
@@ -150,7 +155,8 @@ export class OutOfSpaceError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'OutOfSpaceError';
+    Object.setPrototypeOf(this, OutOfSpaceError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -169,7 +175,8 @@ export class ConnectionError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'ConnectionError';
+    Object.setPrototypeOf(this, ConnectionError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -190,7 +197,8 @@ export class InvalidConfigurationError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'InvalidConfigurationError';
+    Object.setPrototypeOf(this, InvalidConfigurationError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -210,6 +218,9 @@ export class InvalidConfigurationError extends Error {
 export class InvalidAccessTokenError extends InvalidConfigurationError {
   constructor(message: string) {
     super(message);
+
+    this.name = 'InvalidAccessTokenError';
+    Object.setPrototypeOf(this, InvalidAccessTokenError.prototype);
   }
 }
 
@@ -228,7 +239,8 @@ export class UnexpectedError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'UnexpectedError';
+    Object.setPrototypeOf(this, UnexpectedError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -249,7 +261,8 @@ export class MaxResultsExceededError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'MaxResultsExceededError';
+    Object.setPrototypeOf(this, MaxResultsExceededError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -270,7 +283,8 @@ export class MaxFileSizeExceededError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'MaxFileSizeExceededError';
+    Object.setPrototypeOf(this, MaxFileSizeExceededError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -293,7 +307,8 @@ export class IncompleteDataError extends Error {
   constructor(message: string, delay: number) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'IncompleteDataError';
+    Object.setPrototypeOf(this, IncompleteDataError.prototype);
     this.delay = delay;
 
     Error.captureStackTrace(this, this.constructor);
@@ -313,7 +328,8 @@ export class DuplicateDataError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'DuplicateDataError';
+    Object.setPrototypeOf(this, DuplicateDataError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -332,7 +348,8 @@ export class ModuleTimeoutError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'ModuleTimeoutError';
+    Object.setPrototypeOf(this, ModuleTimeoutError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -351,7 +368,8 @@ export class ScenarioTimeoutError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'ScenarioTimeoutError';
+    Object.setPrototypeOf(this, ScenarioTimeoutError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -370,7 +388,8 @@ export class OperationsLimitExceededError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'OperationsLimitExceededError';
+    Object.setPrototypeOf(this, OperationsLimitExceededError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -389,7 +408,8 @@ export class DataSizeLimitExceededError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'DataSizeLimitExceededError';
+    Object.setPrototypeOf(this, DataSizeLimitExceededError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }
@@ -408,7 +428,8 @@ export class ExecutionInterruptedError extends Error {
   constructor(message: string) {
     super(message);
 
-    this.name = this.constructor.name;
+    this.name = 'ExecutionInterruptedError';
+    Object.setPrototypeOf(this, ExecutionInterruptedError.prototype);
 
     Error.captureStackTrace(this, this.constructor);
   }

--- a/src/feeder.ts
+++ b/src/feeder.ts
@@ -6,7 +6,7 @@ import { Bundle, DoneWithResultCallback } from './types';
  * Base class for all Feeders.
  */
 
-export abstract class IMTFeeder extends IMTTransformer {
+export class IMTFeeder extends IMTTransformer {
   public readonly type = ModuleType.FEEDER;
 
   /**

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,4 +1,4 @@
-import { DoneCallback, DoneWithFormCallback, DoneWithInfoCallback } from './types';
+import { DoneCallback, DoneWithFormCallback, DoneWithInfoCallback, DoneWithResultCallback } from './types';
 import type { Request } from 'request';
 
 export type Item = any;
@@ -10,7 +10,7 @@ export type HookData = any;
  * @property {Object} data Collection of data specific to this hook. Read only.
  */
 
-export abstract class IMTHook {
+export class IMTHook {
   /**
    * Initializes the hook. Function that overrides should always call super.
    *
@@ -36,13 +36,17 @@ export abstract class IMTHook {
   /**
    * Parse request.
    *
-   * @param {Request} req Request object.
+   * @param {Request} request Request object.
    * @callback done Callback to call when test is complete.
    *     @param {Error} err Error on error, otherwise null.
    *     @param {Array} items Array of items parsed from request.
    */
 
-  abstract parse(req: Request, done: DoneCallback): void;
+  parse(request: Request, done: DoneWithResultCallback): void {
+    void request;
+    void done;
+    throw new Error("Must override a superclass method 'parse'.");
+  }
   /**
    * Filter received items. Only effective in shared webhooks.
    *

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -9,7 +9,7 @@ import { IMTBase, ModuleType } from './base';
  * @event data Module dispatches this event on new data.
  */
 
-export abstract class IMTListener extends IMTBase {
+export class IMTListener extends IMTBase {
   public readonly type = ModuleType.LISTENER;
 
   /**
@@ -19,7 +19,10 @@ export abstract class IMTListener extends IMTBase {
    *     @param {Error} err Error on error, otherwise null.
    */
 
-  abstract start(done: DoneCallback): void;
+  start(done: DoneCallback): void {
+    void done;
+    throw new Error("Must override a superclass method 'start'.");
+  }
 
   /**
    * Stop listening for new data.
@@ -28,5 +31,8 @@ export abstract class IMTListener extends IMTBase {
    *     @param {Error} err Error on error, otherwise null.
    */
 
-  abstract stop(done: DoneCallback): void;
+  stop(done: DoneCallback): void {
+    void done;
+    throw new Error("Must override a superclass method 'stop'.");
+  }
 }

--- a/src/pauser.ts
+++ b/src/pauser.ts
@@ -1,11 +1,11 @@
 import { IMTBase, ModuleType } from './base';
-import { Bundle, DoneCallback } from './types';
+import { Bundle, DoneWithResultCallback } from './types';
 
 /**
  * Base class for all Feeders.
  */
 
-export abstract class IMTPauser extends IMTBase {
+export class IMTPauser extends IMTBase {
   public readonly type = ModuleType.PAUSER;
 
   /**
@@ -17,5 +17,9 @@ export abstract class IMTPauser extends IMTBase {
    *     @param {Object} bundle Collection of output data.
    */
 
-  abstract pause(bundle: Bundle, done: DoneCallback): void;
+  pause(bundle: Bundle, done: DoneWithResultCallback): void {
+    void bundle;
+    void done;
+    throw new Error("Must override a superclass method 'pause'.");
+  }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,6 +4,6 @@ import { IMTBase, ModuleType } from './base';
  * Base class for all Routers.
  */
 
-export abstract class IMTRouter extends IMTBase {
+export class IMTRouter extends IMTBase {
   public readonly type = ModuleType.ROUTER;
 }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { Common, Environment, Parameters } from './base';
+import { CommonData, EnvironmentData, Parameters } from './base';
 import { DoneCallback, DoneWithResultCallback } from './types';
 
 /**
@@ -10,12 +10,12 @@ import { DoneCallback, DoneWithResultCallback } from './types';
  * @property {Object} parameters Collection of config parameters. Read only.
  */
 
-export abstract class IMTRPC extends EventEmitter {
-  public common: Common | null;
+export class IMTRPC extends EventEmitter {
+  public common: CommonData | null;
   public parameters: Parameters | null;
-  public environment: Environment | null;
+  public environment: EnvironmentData | null;
 
-  protected constructor() {
+  constructor() {
     super();
 
     this.common = null;
@@ -53,7 +53,10 @@ export abstract class IMTRPC extends EventEmitter {
    *     @param {Object} response RPC response.
    */
 
-  abstract execute(done: DoneWithResultCallback): void;
+  execute(done: DoneWithResultCallback): void {
+    void done;
+    throw new Error("Must override a superclass method 'execute'.");
+  }
 
   /**
    * Print debug message to Scenario info log. Debug messages are only visible to system administrators.
@@ -61,5 +64,7 @@ export abstract class IMTRPC extends EventEmitter {
    * @param {...*} message Message to be printed to Scenario info log.
    */
 
-  abstract debug(): void;
+  debug(): void {
+    throw new Error("Must override a superclass method 'debug'.");
+  }
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,11 +1,11 @@
 import { IMTBase, ModuleType } from './base';
-import { Bundle, DoneCallback } from './types';
+import { Bundle, DoneWithResultCallback } from './types';
 
 /**
  * Base class for all Transformers.
  */
 
-export abstract class IMTTransformer extends IMTBase {
+export class IMTTransformer extends IMTBase {
   public readonly type;
 
   constructor(type = ModuleType.TRANSFORMER) {
@@ -21,5 +21,9 @@ export abstract class IMTTransformer extends IMTBase {
    * 	@param {Error} err Error on error, otherwise null.
    * 	@param {Object} bundle Collection of transformed data.
    */
-  abstract transform(bundle: Bundle, done: DoneCallback): void;
+  transform(bundle: Bundle, done: DoneWithResultCallback): void {
+    void bundle;
+    void done;
+    throw new Error("Must override a superclass method 'transform'.");
+  }
 }

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -5,7 +5,7 @@ import { DoneCallback, DoneWithResultCallback } from './types';
  * Base class for all Triggers.
  */
 
-export abstract class IMTTrigger extends IMTBase {
+export class IMTTrigger extends IMTBase {
   public readonly type = ModuleType.TRIGGER;
 
   /**
@@ -16,7 +16,11 @@ export abstract class IMTTrigger extends IMTBase {
    *     @param {Error} err Error on error, otherwise null.
    */
 
-  abstract fetch(id: number, done: DoneCallback): void;
+  fetch(id: number, done: DoneCallback): void {
+    void id;
+    void done;
+    throw new Error("Must override a superclass method 'fetch'.");
+  }
 
   /**
    * Reads data.
@@ -26,11 +30,14 @@ export abstract class IMTTrigger extends IMTBase {
    *     @param {Object|Array} bundle Collection of data read. Or batch of collections.
    */
 
-  abstract read(done: DoneWithResultCallback): void;
+  read(done: DoneWithResultCallback): void {
+    void done;
+    throw new Error("Must override a superclass method 'read'.");
+  }
 }
 
 /**
  * Base Gateway Trigger.
  */
 
-export abstract class IMTGatewayTrigger extends IMTTrigger {}
+export class IMTGatewayTrigger extends IMTTrigger {}

--- a/test/legacy-compatibility.test.ts
+++ b/test/legacy-compatibility.test.ts
@@ -1,0 +1,237 @@
+import '../src/global';
+import * as publicApi from '../src/index';
+
+describe('Legacy Compatibility', () => {
+  const EXTENDABLE_CLASSES = [
+    IMTAggregator,
+    IMTAction,
+    IMTGatewayAction,
+    IMTGatewayResponder,
+    IMTHook,
+    IMTConverger,
+    IMTRouter,
+    IMTListener,
+    IMTAccount,
+    IMTOAuthAccount,
+    IMTTrigger,
+    IMTGatewayTrigger,
+    IMTPauser,
+    IMTBase,
+    IMTRPC,
+    IMTFeeder,
+    IMTTransformer,
+  ];
+
+  it('exports global variables', () => {
+    expect(global.IMT_PROTO_LOADED).toBe(true);
+
+    expect(global.requireCommon).toBeDefined();
+    expect(typeof global.requireCommon).toBe('function');
+
+    expect(global.IMTAggregator).toBeDefined();
+    expect(global.IMTAction).toBeDefined();
+    expect(global.IMTGatewayAction).toBeDefined();
+    expect(global.IMTGatewayResponder).toBeDefined();
+    expect(global.Warning).toBeDefined();
+    expect(global.IMTHook).toBeDefined();
+    expect(global.IMTConverger).toBeDefined();
+    expect(global.UnknownError).toBeDefined();
+    expect(global.RuntimeError).toBeDefined();
+    expect(global.DataError).toBeDefined();
+    expect(global.InconsistencyError).toBeDefined();
+    expect(global.RateLimitError).toBeDefined();
+    expect(global.OutOfSpaceError).toBeDefined();
+    expect(global.ConnectionError).toBeDefined();
+    expect(global.InvalidConfigurationError).toBeDefined();
+    expect(global.InvalidAccessTokenError).toBeDefined();
+    expect(global.UnexpectedError).toBeDefined();
+    expect(global.MaxResultsExceededError).toBeDefined();
+    expect(global.MaxFileSizeExceededError).toBeDefined();
+    expect(global.IncompleteDataError).toBeDefined();
+    expect(global.DuplicateDataError).toBeDefined();
+    expect(global.ModuleTimeoutError).toBeDefined();
+    expect(global.ScenarioTimeoutError).toBeDefined();
+    expect(global.OperationsLimitExceededError).toBeDefined();
+    expect(global.DataSizeLimitExceededError).toBeDefined();
+    expect(global.ExecutionInterruptedError).toBeDefined();
+    expect(global.IMTRouter).toBeDefined();
+    expect(global.IMTListener).toBeDefined();
+    expect(global.IMTAccount).toBeDefined();
+    expect(global.IMTOAuthAccount).toBeDefined();
+    expect(global.IMTTrigger).toBeDefined();
+    expect(global.IMTGatewayTrigger).toBeDefined();
+    expect(global.IMTPauser).toBeDefined();
+    expect(global.IMTBase).toBeDefined();
+    expect(global.IMTRPC).toBeDefined();
+    expect(global.IMTFeeder).toBeDefined();
+    expect(global.IMTTransformer).toBeDefined();
+  });
+
+  it('should have same values for globals and for public API', () => {
+    expect(global.IMTAggregator === publicApi.IMTAggregator).toBe(true);
+    expect(global.IMTAction === publicApi.IMTAction).toBe(true);
+    expect(global.IMTGatewayAction === publicApi.IMTGatewayAction).toBe(true);
+    expect(global.IMTGatewayResponder === publicApi.IMTGatewayResponder).toBe(true);
+    expect(global.Warning === publicApi.Warning).toBe(true);
+    expect(global.IMTHook === publicApi.IMTHook).toBe(true);
+    expect(global.IMTConverger === publicApi.IMTConverger).toBe(true);
+    expect(global.UnknownError === publicApi.UnknownError).toBe(true);
+    expect(global.RuntimeError === publicApi.RuntimeError).toBe(true);
+    expect(global.DataError === publicApi.DataError).toBe(true);
+    expect(global.InconsistencyError === publicApi.InconsistencyError).toBe(true);
+    expect(global.RateLimitError === publicApi.RateLimitError).toBe(true);
+    expect(global.OutOfSpaceError === publicApi.OutOfSpaceError).toBe(true);
+    expect(global.ConnectionError === publicApi.ConnectionError).toBe(true);
+    expect(global.InvalidConfigurationError === publicApi.InvalidConfigurationError).toBe(true);
+    expect(global.InvalidAccessTokenError === publicApi.InvalidAccessTokenError).toBe(true);
+    expect(global.UnexpectedError === publicApi.UnexpectedError).toBe(true);
+    expect(global.MaxResultsExceededError === publicApi.MaxResultsExceededError).toBe(true);
+    expect(global.MaxFileSizeExceededError === publicApi.MaxFileSizeExceededError).toBe(true);
+    expect(global.IncompleteDataError === publicApi.IncompleteDataError).toBe(true);
+    expect(global.DuplicateDataError === publicApi.DuplicateDataError).toBe(true);
+    expect(global.ModuleTimeoutError === publicApi.ModuleTimeoutError).toBe(true);
+    expect(global.ScenarioTimeoutError === publicApi.ScenarioTimeoutError).toBe(true);
+    expect(global.OperationsLimitExceededError === publicApi.OperationsLimitExceededError).toBe(true);
+    expect(global.DataSizeLimitExceededError === publicApi.DataSizeLimitExceededError).toBe(true);
+    expect(global.ExecutionInterruptedError === publicApi.ExecutionInterruptedError).toBe(true);
+    expect(global.IMTRouter === publicApi.IMTRouter).toBe(true);
+    expect(global.IMTListener === publicApi.IMTListener).toBe(true);
+    expect(global.IMTAccount === publicApi.IMTAccount).toBe(true);
+    expect(global.IMTOAuthAccount === publicApi.IMTOAuthAccount).toBe(true);
+    expect(global.IMTTrigger === publicApi.IMTTrigger).toBe(true);
+    expect(global.IMTGatewayTrigger === publicApi.IMTGatewayTrigger).toBe(true);
+    expect(global.IMTPauser === publicApi.IMTPauser).toBe(true);
+    expect(global.IMTBase === publicApi.IMTBase).toBe(true);
+    expect(global.IMTRPC === publicApi.IMTRPC).toBe(true);
+    expect(global.IMTFeeder === publicApi.IMTFeeder).toBe(true);
+    expect(global.IMTTransformer === publicApi.IMTTransformer).toBe(true);
+  });
+
+  it('should be compatible with CoffeeScript classes', () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const hasProp = {}.hasOwnProperty;
+    const extend = function (child: any, parent: any): any {
+      for (const key in parent) {
+        if (hasProp.call(parent, key)) child[key] = parent[key];
+      }
+      function Constructor(this: any) {
+        this.constructor = child;
+      }
+      Constructor.prototype = parent.prototype;
+      child.prototype = new (Constructor as any)();
+      child.__super__ = parent.prototype;
+      return child;
+    };
+
+    for (const extendableClass of EXTENDABLE_CLASSES) {
+      const CoffeeClass = (function (superClass) {
+        extend(CoffeeClass, superClass);
+
+        function CoffeeClass(this: any) {
+          // eslint-disable-next-line prefer-rest-params,@typescript-eslint/no-unsafe-return
+          return CoffeeClass.__super__!.constructor.apply(this, arguments);
+        }
+
+        return CoffeeClass;
+      })(extendableClass);
+
+      const instance = new (CoffeeClass as any)();
+      expect(instance).toBeInstanceOf(CoffeeClass);
+      expect(instance).toBeInstanceOf(extendableClass);
+    }
+  });
+
+  it('should allow extending class using .inherits', () => {
+    for (const extendableClass of EXTENDABLE_CLASSES) {
+      const ChildClass = (function factory(supr) {
+        ChildClass.inherits(supr);
+
+        function ChildClass(this: any) {
+          ChildClass.__super__!.constructor.call(this);
+        }
+
+        return ChildClass;
+      })(extendableClass);
+
+      const instance = new (ChildClass as any)();
+      expect(instance).toBeInstanceOf(ChildClass);
+      expect(instance).toBeInstanceOf(extendableClass);
+    }
+  });
+
+  it('should allow extending class using ES6 extends', () => {
+    for (const extendableClass of EXTENDABLE_CLASSES) {
+      class ChildClass extends extendableClass {}
+
+      const instance = new ChildClass();
+      expect(instance).toBeInstanceOf(ChildClass);
+      expect(instance).toBeInstanceOf(extendableClass);
+    }
+  });
+
+  it('should have correct names on error classes', () => {
+    expect(new UnknownError('').name).toBe('UnknownError');
+    expect(new RuntimeError('').name).toBe('RuntimeError');
+    expect(new DataError('').name).toBe('DataError');
+    expect(new InconsistencyError('').name).toBe('InconsistencyError');
+    expect(new RateLimitError('', 1).name).toBe('RateLimitError');
+    expect(new OutOfSpaceError('').name).toBe('OutOfSpaceError');
+    expect(new ConnectionError('').name).toBe('ConnectionError');
+    expect(new InvalidConfigurationError('').name).toBe('InvalidConfigurationError');
+    expect(new InvalidAccessTokenError('').name).toBe('InvalidAccessTokenError');
+    expect(new UnexpectedError('').name).toBe('UnexpectedError');
+    expect(new MaxResultsExceededError('').name).toBe('MaxResultsExceededError');
+    expect(new MaxFileSizeExceededError('').name).toBe('MaxFileSizeExceededError');
+    expect(new IncompleteDataError('', 1).name).toBe('IncompleteDataError');
+    expect(new DuplicateDataError('').name).toBe('DuplicateDataError');
+    expect(new ModuleTimeoutError('').name).toBe('ModuleTimeoutError');
+    expect(new ScenarioTimeoutError('').name).toBe('ScenarioTimeoutError');
+    expect(new OperationsLimitExceededError('').name).toBe('OperationsLimitExceededError');
+    expect(new DataSizeLimitExceededError('').name).toBe('DataSizeLimitExceededError');
+    expect(new ExecutionInterruptedError('').name).toBe('ExecutionInterruptedError');
+  });
+
+  it('should have correct name on the constructor', () => {
+    expect(new UnknownError('').constructor.name).toBe('UnknownError');
+    expect(new RuntimeError('').constructor.name).toBe('RuntimeError');
+    expect(new DataError('').constructor.name).toBe('DataError');
+    expect(new InconsistencyError('').constructor.name).toBe('InconsistencyError');
+    expect(new RateLimitError('', 1).constructor.name).toBe('RateLimitError');
+    expect(new OutOfSpaceError('').constructor.name).toBe('OutOfSpaceError');
+    expect(new ConnectionError('').constructor.name).toBe('ConnectionError');
+    expect(new InvalidConfigurationError('').constructor.name).toBe('InvalidConfigurationError');
+    expect(new InvalidAccessTokenError('').constructor.name).toBe('InvalidAccessTokenError');
+    expect(new UnexpectedError('').constructor.name).toBe('UnexpectedError');
+    expect(new MaxResultsExceededError('').constructor.name).toBe('MaxResultsExceededError');
+    expect(new MaxFileSizeExceededError('').constructor.name).toBe('MaxFileSizeExceededError');
+    expect(new IncompleteDataError('', 1).constructor.name).toBe('IncompleteDataError');
+    expect(new DuplicateDataError('').constructor.name).toBe('DuplicateDataError');
+    expect(new ModuleTimeoutError('').constructor.name).toBe('ModuleTimeoutError');
+    expect(new ScenarioTimeoutError('').constructor.name).toBe('ScenarioTimeoutError');
+    expect(new OperationsLimitExceededError('').constructor.name).toBe('OperationsLimitExceededError');
+    expect(new DataSizeLimitExceededError('').constructor.name).toBe('DataSizeLimitExceededError');
+    expect(new ExecutionInterruptedError('').constructor.name).toBe('ExecutionInterruptedError');
+  });
+
+  it('should have working instanceof operator', () => {
+    expect(new UnknownError('') instanceof UnknownError).toBe(true);
+    expect(new RuntimeError('') instanceof RuntimeError).toBe(true);
+    expect(new DataError('') instanceof DataError).toBe(true);
+    expect(new InconsistencyError('') instanceof InconsistencyError).toBe(true);
+    expect(new RateLimitError('', 1) instanceof RateLimitError).toBe(true);
+    expect(new OutOfSpaceError('') instanceof OutOfSpaceError).toBe(true);
+    expect(new ConnectionError('') instanceof ConnectionError).toBe(true);
+    expect(new InvalidConfigurationError('') instanceof InvalidConfigurationError).toBe(true);
+    expect(new InvalidAccessTokenError('') instanceof InvalidAccessTokenError).toBe(true);
+    expect(new UnexpectedError('') instanceof UnexpectedError).toBe(true);
+    expect(new MaxResultsExceededError('') instanceof MaxResultsExceededError).toBe(true);
+    expect(new MaxFileSizeExceededError('') instanceof MaxFileSizeExceededError).toBe(true);
+    expect(new IncompleteDataError('', 1) instanceof IncompleteDataError).toBe(true);
+    expect(new DuplicateDataError('') instanceof DuplicateDataError).toBe(true);
+    expect(new ModuleTimeoutError('') instanceof ModuleTimeoutError).toBe(true);
+    expect(new ScenarioTimeoutError('') instanceof ScenarioTimeoutError).toBe(true);
+    expect(new OperationsLimitExceededError('') instanceof OperationsLimitExceededError).toBe(true);
+    expect(new DataSizeLimitExceededError('') instanceof DataSizeLimitExceededError).toBe(true);
+    expect(new ExecutionInterruptedError('') instanceof ExecutionInterruptedError).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES5",
     "module": "CommonJS",
     "lib": ["ESNext"],
     "outDir": "./dist",


### PR DESCRIPTION
## We can't have nice things because of the legacy code

I am dropping abstract classes and using ES5 transpilation + necessary fixes to make the ES5 classes work.

## Changes

- Change `target` in `tsconfig.json` from `ESNext` to `ES5`
- Rename `Common` to `CommonData` and `Data` to `ModuleData` in multiple files to better express their meaning
- Change `IMTAccount`, `IMTOAuthAccount`, `IMTAction`, `IMTGatewayAction`, `IMTGatewayResponder`, `IMTAggregator`, `IMTBase`, `IMTConverger`, `IMTRouter`, `IMTListener`, `IMTPauser`, `IMTRPC`, `IMTFeeder`, `IMTTransformer`, `IMTTrigger`, and `IMTGatewayTrigger` from abstract to regular classes
- Add error throw for unimplemented methods in `IMTAction`, `IMTBase`, `IMTHook`, `IMTListener`, `IMTPauser`, `IMTRPC`, `IMTTransformer`, and `IMTTrigger` classes
- Change `this.name` assignment in multiple error classes to use hardcoded string values and set object's prototype to its constructor - I feel hardcoded values are safer
- Add a new test file `legacy-compatibility.test.ts` that checks for legacy compatibility with the changes made