### PR TITLE
fix: make sure IMT classes form correct discriminated union

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.12"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/aggregator.ts
+++ b/src/aggregator.ts
@@ -6,7 +6,5 @@ import { IMTTransformer } from './transformer';
  */
 
 export class IMTAggregator extends IMTTransformer {
-  constructor() {
-    super(ModuleType.AGGREGATOR);
-  }
+  public readonly type = ModuleType.AGGREGATOR;
 }

--- a/src/hitl.ts
+++ b/src/hitl.ts
@@ -4,8 +4,8 @@ import { Bundle, DoneWithInfoCallback } from './types';
 /**
  * Base class for all Human-in-the-loop modules.
  */
-export abstract class IMTHITL extends IMTBase {
-  public readonly type: ModuleType = ModuleType.HITL;
+export class IMTHITL extends IMTBase {
+  public readonly type = ModuleType.HITL;
 
   /**
    * Executes the HITL flow.
@@ -15,5 +15,9 @@ export abstract class IMTHITL extends IMTBase {
    *     @param {Error} err Error on error, otherwise null.
    */
 
-  abstract execute(bundle: Bundle, done: DoneWithInfoCallback): void;
+  execute(bundle: Bundle, done: DoneWithInfoCallback): void {
+    void bundle;
+    void done;
+    throw new Error("Must override a superclass method 'execute'.");
+  }
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -6,12 +6,7 @@ import { Bundle, DoneWithResultCallback } from './types';
  */
 
 export class IMTTransformer extends IMTBase {
-  public readonly type;
-
-  constructor(type = ModuleType.TRANSFORMER) {
-    super();
-    this.type = type;
-  }
+  public readonly type: ModuleType.TRANSFORMER | ModuleType.AGGREGATOR | ModuleType.FEEDER = ModuleType.TRANSFORMER;
 
   /**
    * Transforms data.

--- a/test/module-type.spec.ts
+++ b/test/module-type.spec.ts
@@ -1,0 +1,68 @@
+import {
+  IMTAction,
+  IMTAggregator,
+  IMTConverger,
+  IMTFeeder,
+  IMTHITL,
+  IMTListener,
+  IMTPauser,
+  IMTRouter,
+  IMTTransformer,
+  IMTTrigger,
+  ModuleType,
+} from '../src';
+
+describe('ModuleType', () => {
+  it('should be discriminated union', () => {
+    const allModuleTypes = [
+      new IMTAction(),
+      new IMTAggregator(),
+      new IMTConverger(),
+      new IMTFeeder(),
+      new IMTHITL(),
+      new IMTListener(),
+      new IMTPauser(),
+      new IMTRouter(),
+      new IMTTransformer(),
+      new IMTTrigger(),
+    ];
+
+    for (const module of allModuleTypes) {
+      // NOTE(m.skvely): This code will trigger a TypeScript error if the type is not correctly discriminated
+      switch (module.type) {
+        case ModuleType.TRIGGER:
+          expect(module).toBeInstanceOf(IMTTrigger);
+          break;
+        case ModuleType.TRANSFORMER:
+          expect(module).toBeInstanceOf(IMTTransformer);
+          break;
+        case ModuleType.ROUTER:
+          expect(module).toBeInstanceOf(IMTRouter);
+          break;
+        case ModuleType.ACTION:
+          expect(module).toBeInstanceOf(IMTAction);
+          break;
+        case ModuleType.LISTENER:
+          expect(module).toBeInstanceOf(IMTListener);
+          break;
+        case ModuleType.FEEDER:
+          expect(module).toBeInstanceOf(IMTFeeder);
+          break;
+        case ModuleType.AGGREGATOR:
+          expect(module).toBeInstanceOf(IMTAggregator);
+          break;
+        case ModuleType.CONVERGER:
+          expect(module).toBeInstanceOf(IMTConverger);
+          break;
+        case ModuleType.HITL:
+          expect(module).toBeInstanceOf(IMTHITL);
+          break;
+        case ModuleType.PAUSER:
+          expect(module).toBeInstanceOf(IMTPauser);
+          break;
+        default:
+          throw new Error('Unexpected module type');
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Overview

Refactor IMT classes to form discriminated unions

## Changes

- Refactor `IMTAggregator` to use a readonly `type` property instead of constructor initialization
- Change `IMTHITL` from abstract to concrete class and implement a default `execute` method throwing an error
- Refactor `IMTTransformer` to use a discriminated `type` union property instead of constructor initialization
- Add a new test file `module-type.spec.ts` to verify that `ModuleType` is a correctly discriminated union through instance checks
- Bump package version from `2.5.0` to `2.5.1`

[CDM-12098](https://make.atlassian.net/browse/CDM-12098)

[CDM-12098]: https://make.atlassian.net/browse/CDM-12098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ