### PR TITLE
fix: correctly serialize Error objects

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -466,9 +466,9 @@ Object.defineProperty(Error.prototype, 'toJSON', {
 
     if (this.hash != null) json.hash = this.hash;
     if (this.bundle != null) json.bundle = this.bundle;
-    if (Array.isArray(this.suberrors)) json.suberrors = this.suberrors.map((item: Error) => item.toJSON());
+    if (Array.isArray(this.suberrors)) json.suberrors = this.suberrors.map((item: Error) => item);
     if (this.external != null) json.external = this.external;
-    if (this.imtInternalError) json.imtInternalError = this.imtInternalError.toJSON();
+    if (this.imtInternalError) json.imtInternalError = this.imtInternalError;
     if (this.imtExceptionHash) json.imtExceptionHash = this.imtExceptionHash;
 
     return json;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,10 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
 }


### PR DESCRIPTION
## Overview

Don't fail on sub-error objects that are not Error class instances

## Changes

- Change JSON serialization behavior to include sub-errors and `imtInternalError` directly without calling `toJSON`.
- Remove `done` callback from asynchronous test cases, converting them to synchronous.
- Add multiple test cases for JSON serialization, including handling of sub-errors, nested sub-errors, and sub-errors that are not instances of the Error class.
- Update `tsconfig.json` to include a reference to `tsconfig.spec.json`.

[CDM-12791](https://make.atlassian.net/browse/CDM-12791)

[CDM-12791]: https://make.atlassian.net/browse/CDM-12791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ