### PR TITLE
feat: adds metadata to operation result

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,5 @@
 import { IMTBase, ModuleType } from './base';
-import { Bundle, DoneWithInfoCallback } from './types';
+import { Bundle, DoneWithResultCallback } from './types';
 
 export class IMTAction extends IMTBase {
   public readonly type = ModuleType.ACTION;
@@ -12,7 +12,7 @@ export class IMTAction extends IMTBase {
    *     @param {Error} err Error on error, otherwise null.
    */
 
-  write(bundle: Bundle, done: DoneWithInfoCallback): void {
+  write(bundle: Bundle, done: DoneWithResultCallback): void {
     void bundle;
     void done;
     throw new Error("Must override a superclass method 'write'.");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,24 @@
 export type Bundle = { array?: Array<any> } & Record<string, any>;
 
+export type Link = {
+  type: 'link';
+  valueLabel: string;
+  resourceId: string;
+  resourceType: 'execution' | 'scenario';
+  additionalParams: Record<string, string>;
+};
+
+export type Metadata = {
+  version: number;
+  keyLabel: string;
+} & Link;
+
 export type DoneCallback = (err?: Error | null) => void;
 
 export type DoneWithInfoCallback = (err?: Error | null, done?: any) => void;
 
 export type DoneWithReportCallback = (err?: Error | null, report?: any[] | null) => void;
 
-export type DoneWithResultCallback = (err?: Error | null, result?: any) => void;
+export type DoneWithResultCallback = (err?: Error | null, result?: any, metadata?: Array<Metadata>) => void;
 
 export type DoneWithFormCallback = (err?: Error | null, form?: any) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,9 @@ export type Bundle = { array?: Array<any> } & Record<string, any>;
 export type Link = {
   type: 'link';
   valueLabel: string;
-  resourceId: string;
+  resourceId?: string;
   resourceType: 'execution' | 'scenario';
-  additionalParams: Record<string, string>;
+  additionalParams?: Record<string, string>;
 };
 
 export type Metadata = {


### PR DESCRIPTION
https://make.atlassian.net/browse/CDM-13775

We want to allow the apps to pass some metadata about the action. For now it is just a link, but in the future we see a potential to add extra information. 

Since the link needs to be constructed on the FE, we are only describing a resource to which the FE should point to. The resource ID the main thing that you point to, however the route could have some other parts (like team id, scenario id etc.) which would be indicated in the additionalParams (for example `{ scenarioId: 1, teamId: 2}`) 

Both resource ID and the additionalParams are optional, since you could also be pointing to a static route

![Screenshot 2025-03-24 at 15 23 50](https://github.com/user-attachments/assets/b9f53e8c-ad37-4a2d-a1d9-dfa6ddb47e91)
