### PR TITLE
fix(base): module types constant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.12"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.8.0",
+  "version": "2.8.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/base.ts
+++ b/src/base.ts
@@ -36,20 +36,20 @@ export enum ModuleType {
 }
 
 export const moduleTypeNames = {
-  [ModuleType.TRIGGER]: { singular: 'trigger', plural: 'triggers' },
-  [ModuleType.TRANSFORMER]: { singular: 'transformer', plural: 'transformers' },
-  [ModuleType.ROUTER]: { singular: 'router', plural: 'routers' },
-  [ModuleType.ACTION]: { singular: 'action', plural: 'actions' },
-  [ModuleType.LISTENER]: { singular: 'listener', plural: 'listeners' },
-  [ModuleType.FEEDER]: { singular: 'feeder', plural: 'feeders' },
-  [ModuleType.AGGREGATOR]: { singular: 'aggregator', plural: 'aggregators' },
-  [ModuleType.DIRECTIVE]: { singular: 'directive', plural: 'directives' },
-  [ModuleType.SEARCH]: { singular: 'search', plural: 'searches' },
-  [ModuleType.CONVERGER]: { singular: 'converger', plural: 'convergers' },
-  [ModuleType.HITL]: { singular: 'hitl', plural: 'hitls' },
-  [ModuleType.RETURNER]: { singular: 'returner', plural: 'returners' },
-  [ModuleType.PAUSER]: { singular: 'pauser', plural: 'pausers' },
-  [ModuleType.STARTER]: { singular: 'starter', plural: 'starters' },
+  [ModuleType.TRIGGER]: { singular: 'trigger', plural: 'triggers' } as const,
+  [ModuleType.TRANSFORMER]: { singular: 'transformer', plural: 'transformers' } as const,
+  [ModuleType.ROUTER]: { singular: 'router', plural: 'routers' } as const,
+  [ModuleType.ACTION]: { singular: 'action', plural: 'actions' } as const,
+  [ModuleType.LISTENER]: { singular: 'listener', plural: 'listeners' } as const,
+  [ModuleType.FEEDER]: { singular: 'feeder', plural: 'feeders' } as const,
+  [ModuleType.AGGREGATOR]: { singular: 'aggregator', plural: 'aggregators' } as const,
+  [ModuleType.DIRECTIVE]: { singular: 'directive', plural: 'directives' } as const,
+  [ModuleType.SEARCH]: { singular: 'search', plural: 'searches' } as const,
+  [ModuleType.CONVERGER]: { singular: 'converger', plural: 'convergers' } as const,
+  [ModuleType.HITL]: { singular: 'hitl', plural: 'hitls' } as const,
+  [ModuleType.RETURNER]: { singular: 'returner', plural: 'returners' } as const,
+  [ModuleType.PAUSER]: { singular: 'pauser', plural: 'pausers' } as const,
+  [ModuleType.STARTER]: { singular: 'starter', plural: 'starters' } as const,
 };
 
 /**


### PR DESCRIPTION
In order to allow accessing module types through `keyof typeof` and so on when defining custom types, we're adding `as const` casts to the `moduleTypeNames` enum.

_As this is related only to the typings and not to the actual code, we deem this change small enough to pass the no-ticket-required gate_