### PR TITLE
chore(release): patch version bump again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.12"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "node": ">=16.19.0"
   },
   "scripts": {
+    "prepublishOnly": "npm run build && npm test",
     "build": "tsc --build tsconfig.json --clean && tsc --build tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.8.1",
+  "version": "2.8.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Because we've failed to build the Proto Library before publishing it, we're fixing this and actually saving our future selves by adding the `prepublishOnly` and bumping the version again.

_Change deemed small enough to not require a ticket, as it's not impacting the actual production code, just the pipeline_