### PR TITLE
feat(credit): credits types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,18 +2,33 @@ export type Bundle = { array?: Array<any> } & Record<string, any>;
 
 export type Link = {
   type: 'link';
+  keyLabel: string;
   valueLabel: string;
   resourceId?: string;
   resourceType: 'execution' | 'scenario';
   additionalParams?: Record<string, any>;
 };
 
+export type Centicredits = {
+  type: 'centicredits';
+  additionalParams: {
+    centicreditsConsumption?: number;
+    [key: string]: any;
+  };
+};
+
 export type Metadata = {
   version: number;
-  keyLabel: string;
-} & Link;
+} & (Link | Centicredits);
 
 export type MetadataList = Array<Metadata>;
+
+export type CenticreditsConsumption = {
+  module: {
+    cost: number;
+    duration: number;
+  };
+};
 
 export type DoneCallback = (err?: Error | null) => void;
 


### PR DESCRIPTION
https://make.atlassian.net/browse/CDM-14600

- `Centicredits` type describing centicredits metadata that can be reported by the module
- `CenticreditsConsumption` type describes data pushed to activity stream in message of type OPERATION_END