### PR TITLE
feat: adds metadata to agent finish action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.9.4",
+  "version": "2.9.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,5 @@
 import { IMTBase, ModuleType } from './base';
-import { Bundle } from './types';
+import { Bundle, Metadata, MetadataList } from './types';
 
 export type AgentResources = {
   agentOutputSpec: Readonly<Record<string, any>>;
@@ -31,6 +31,7 @@ export type UseToolAction = Readonly<{
 export type FinishAction = Readonly<
   {
     type: 'finishAction';
+    metadata?: Readonly<MetadataList>;
   } & (
     | Readonly<{
         status: 'SUCCESS';


### PR DESCRIPTION
https://make.atlassian.net/browse/NEX-681

Adds metadata to the Agent finish action. Allow agent to pass the centicredits usage to the engine