### PR TITLE
feat: extend parameters in getThreadHistory method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.9.5",
+      "version": "2.9.6",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.9.6",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.9.6",
+      "version": "2.10.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.10.0",
+  "version": "2.11.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.9.6",
+  "version": "2.10.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.9.5",
+  "version": "2.9.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -73,6 +73,7 @@ export type ThreadContext = Readonly<{ history: ThreadHistory }>;
 
 export type GetThreadContextParams = Readonly<{
   threadId: string;
+  iterationsFromHistoryCount?: number;
 }>;
 
 export class IMTAgent extends IMTBase {


### PR DESCRIPTION
https://make.atlassian.net/browse/WM-3242

This PR adds new optional parameter `iterationsFromHistoryCount` to `getThreadContext()` method so we can limit the result count directly from the module settings.