### PR TITLE
ci: add NPM publish as GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: NPM Publish
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+" # On the new tag semantic version (1.1.3)
+  workflow_dispatch:
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install npm supporting trusted publishing
+        shell: bash
+        # Ensure npm 11.5.1 or later for trusted publishing (OIDC)
+        run: npm install -g npm@11.6.0
+
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - run: npm run build
+
+      - name: Check package.json version matches Git tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "✅ Manual trigger: using package.json version $PACKAGE_VERSION"
+          else
+            TAG_VERSION=${GITHUB_REF#refs/tags/}
+
+            if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+              echo "Version mismatch! package.json version '$PACKAGE_VERSION' does not match Git tag '$TAG_VERSION'."
+              exit 1
+            fi
+
+            echo "✅ Version check passed: $PACKAGE_VERSION"
+          fi
+
+      - name: Publish to NPM
+        run: npm publish


### PR DESCRIPTION
Stolen from https://github.com/integromat/agentic-app-dev/blob/main/.github/workflows/publish.yml and modified to Node 20.

Hopefully it will work automagically.
