### PR TITLE
feat(proto): add filterExclude to AgentResources tool type

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,6 +10,7 @@ export type AgentResources = {
         name: string;
         description: string;
         inputSchema: Readonly<Record<string, any>>;
+        excludedOutputFields?: Readonly<string[]>;
       }>
     >
   >;


### PR DESCRIPTION
[Has Ai Code]

### Context

Part of the engine-side tool-call filtering initiative (WM-4114). Replaces the hardcoded SetVariables module approach that caused billing issues (WM-4094).

### What this does

Adds an optional `filterExclude` field (readonly string array) to the tool type in `AgentResources`. The native app reads this field to strip excluded properties from tool output before passing it to the LLM.

### Notes
- Additive, optional field. Fully backward compatible.
- Consumed by `ai-local-agent` in the mono repo.
- Populated by `make-core` engine from `tool.options.filterExclude` in the blueprint.

https://make.atlassian.net/browse/WM-4114