### PR TITLE
feat: add progress() method and ProgressContent type to IMTBase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.12.0",
+  "version": "2.13.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/base.ts
+++ b/src/base.ts
@@ -17,6 +17,11 @@ export type EnvironmentData = Record<string, any>;
 
 export type InternalData = Record<string, any>;
 
+/** `type` namespaces the producing app's variants; `event` discriminates within a namespace. */
+export type ProgressContent =
+  | { type: 'aiBrowserProgress'; event: 'sessionStarted'; liveViewUrl?: string }
+  | { type: 'aiBrowserProgress'; event: 'step'; stepIndex: number; summary: string; stepType?: string };
+
 export enum ModuleType {
   NONE = 0,
   TRIGGER = 1,
@@ -68,6 +73,7 @@ export const moduleTypeNames = {
  *
  * @event log - Dispatched when message is about to be printed to info log.
  * @event warn - Dispatched when message is about to be printed to warning log.
+ * @event progress - Dispatched when module reports execution progress.
  */
 export class IMTBase extends EventEmitter {
   public readonly type: ModuleType = ModuleType.NONE;
@@ -174,6 +180,16 @@ export class IMTBase extends EventEmitter {
     } else {
       this.emit('log', util.format(...args));
     }
+  }
+
+  /**
+   * Report module execution progress to Scenario execution log.
+   *
+   * @param {ProgressContent} content Progress content to be added to the Module Execution Log.
+   */
+
+  progress(content: ProgressContent) {
+    this.emit('progress', content);
   }
 
   /**

--- a/src/base.ts
+++ b/src/base.ts
@@ -17,6 +17,10 @@ export type EnvironmentData = Record<string, any>;
 
 export type InternalData = Record<string, any>;
 
+export type ProgressContent =
+  | { type: 'aiBrowserProgress'; event: 'sessionStarted'; liveViewUrl?: string }
+  | { type: 'aiBrowserProgress'; event: 'step'; stepIndex: number; summary: string; stepType?: string };
+
 export enum ModuleType {
   NONE = 0,
   TRIGGER = 1,
@@ -68,6 +72,7 @@ export const moduleTypeNames = {
  *
  * @event log - Dispatched when message is about to be printed to info log.
  * @event warn - Dispatched when message is about to be printed to warning log.
+ * @event progress - Dispatched when module reports execution progress.
  */
 export class IMTBase extends EventEmitter {
   public readonly type: ModuleType = ModuleType.NONE;
@@ -174,6 +179,16 @@ export class IMTBase extends EventEmitter {
     } else {
       this.emit('log', util.format(...args));
     }
+  }
+
+  /**
+   * Report module execution progress to Scenario execution log.
+   *
+   * @param {ProgressContent} content Progress content to be added to the Module Execution Log.
+   */
+
+  progress(content: ProgressContent) {
+    this.emit('progress', content);
   }
 
   /**

--- a/test/base.spec.ts
+++ b/test/base.spec.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+import { IMTBase, ProgressContent } from '../src/base';
+
+class TestModule extends IMTBase {}
+
+describe('IMTBase', () => {
+  describe('progress', () => {
+    it('should emit progress event with sessionStarted content', (done) => {
+      const module = new TestModule();
+      const content: ProgressContent = {
+        type: 'aiBrowserProgress',
+        event: 'sessionStarted',
+        liveViewUrl: 'https://example.com/live',
+      };
+
+      module.on('progress', (received) => {
+        assert.deepStrictEqual(received, content);
+        module.finalize(done);
+      });
+
+      module.progress(content);
+    });
+
+    it('should emit progress event with step content', (done) => {
+      const module = new TestModule();
+      const content: ProgressContent = {
+        type: 'aiBrowserProgress',
+        event: 'step',
+        stepIndex: 1,
+        summary: 'Navigated to example.com',
+        stepType: 'tool-call',
+      };
+
+      module.on('progress', (received) => {
+        assert.deepStrictEqual(received, content);
+        module.finalize(done);
+      });
+
+      module.progress(content);
+    });
+  });
+});


### PR DESCRIPTION
## Context

The AI Browser native app streams live agent progress to the Inspector sidebar. The engine relays these events to the module execution log (`MODULE_PROGRESS` records), but until now there was no typed contract for what native apps may emit — the original engine-side relay was rejected for being a blind, unvalidated pass-through.

This PR adds that contract to the proto layer:

- `ProgressContent` — discriminated union (`type` namespaces the producing app, `event` discriminates within it; AI Browser is the first producer)
- `IMTBase.progress(content)` — typed emitter mirroring the existing `log()`/`warn()`/`debug()` methods
- Tests for both variants
- Version bump `2.12.0` → `2.13.0` (minor — new backward-compatible API)

Runtime validation (Zod schema, payload size guard, rate limiting) deliberately stays in make-core — imt-proto remains a pure type/class layer.

## Notes

- After merge, publishing is manual: Actions → **NPM Publish** → run on `master`. make-core and mono consume the new API only once `2.13.0` is on npm.

## Links

- RFC: https://make.atlassian.net/wiki/spaces/RD/pages/3167453198/RFC+Live+Progress+Streaming+for+Ai+Browsing+Native+App
- Jira: [SPAR-154](https://make.atlassian.net/browse/SPAR-154)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SPAR-154]: https://make.atlassian.net/browse/SPAR-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ