### PR TITLE
chore: remove make-coverage upload step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,6 @@ jobs:
       - testing-orb/run_tests:
           test_type: unit
           command: npm run test:unit
-      - testing-orb/upload_and_comment_coverage:
-          lcov_file_path: ./coverage/unit/lcov.info
-          test_type: unit
       - store_artifacts:
           path: coverage/unit
       - store_test_results:


### PR DESCRIPTION
## Summary
- remove `testing-orb/upload_and_comment_coverage` from the CircleCI pipeline
- leave test execution, test result storage, and coverage artifacts in place

## Validation
- YAML parse of `.circleci/config.yml`
- `git diff --check -- .circleci/config.yml`

Part of the make-coverage shutdown cleanup. This should merge before publishing a `testing-orb` version that removes the command: integromat/testing-orb#37.