### PR TITLE
feat: add internal-tool handoff action types (WM-4067)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.13.0",
+  "version": "2.14.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -30,6 +30,28 @@ export type UseToolAction = Readonly<{
   content?: Readonly<string>;
 }>;
 
+export type InternalToolCall = Readonly<{
+  toolCallId: string;
+  name: string;
+  input: Readonly<Bundle>;
+}>;
+
+export type UseInternalToolAction = Readonly<{
+  type: 'useInternalToolAction';
+  internalTool: InternalToolCall;
+  context: AgentContext;
+  reasoning?: Readonly<string>;
+  content?: Readonly<string>;
+}>;
+
+export type InternalToolResultAction = Readonly<
+  {
+    type: 'internalToolResultAction';
+    context: AgentContext;
+    executionTime?: number;
+  } & (Readonly<{ status: 'SUCCESS'; resultBundle: Readonly<Bundle> }> | Readonly<{ status: 'ERROR'; error: Error }>)
+>;
+
 export type FinishAction = Readonly<
   {
     type: 'finishAction';
@@ -46,7 +68,7 @@ export type FinishAction = Readonly<
   )
 >;
 
-export type Action = UseToolAction | FinishAction;
+export type Action = UseToolAction | UseInternalToolAction | InternalToolResultAction | FinishAction;
 
 export type InitialActionResult = Readonly<{
   type: 'initialActionResult';
@@ -61,11 +83,17 @@ export type PreviousActionResult = Readonly<{
   type: 'previousActionResult';
   context: AgentContext;
   status: 'SUCCESS' | 'ERROR' | 'WARNING';
-  previousAction: UseToolAction;
+  previousAction: UseToolAction | UseInternalToolAction;
   previousActionResult: PreviousActionResultValue;
 }>;
 
-export type NextActionParams = InitialActionResult | PreviousActionResult;
+export type ExecuteInternalToolParams = Readonly<{
+  type: 'executeInternalToolParams';
+  internalTool: InternalToolCall;
+  context: AgentContext;
+}>;
+
+export type NextActionParams = InitialActionResult | PreviousActionResult | ExecuteInternalToolParams;
 
 export type ThreadHistoryRecord = Readonly<Record<any, any>>;
 export type ThreadHistory = Readonly<{

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -47,9 +47,13 @@ export type UseInternalToolAction = Readonly<{
 export type InternalToolResultAction = Readonly<
   {
     type: 'internalToolResultAction';
+    toolCallId: string;
     context: AgentContext;
     executionTime?: number;
-  } & (Readonly<{ status: 'SUCCESS'; resultBundle: Readonly<Bundle> }> | Readonly<{ status: 'ERROR'; error: Error }>)
+  } & (
+    | Readonly<{ status: 'SUCCESS'; toolOutputBundle: Readonly<Bundle> }>
+    | Readonly<{ status: 'ERROR'; error: Error }>
+  )
 >;
 
 export type FinishAction = Readonly<


### PR DESCRIPTION
https://make.atlassian.net/browse/WM-4067

## Why

Internal tools (file-generator) currently execute inline inside make-ai-agents-api with no engine visibility — the inspector reasoning panel never shows the call, and a single AbortController timeout wraps both the LLM step and the inline tool execution, so a slow tool can time out the whole step.

This change adds the action types needed for the engine to round-trip internal tools the same way it round-trips external Make tools — visibility in the reasoning panel, plus an independent timeout per internal tool call.

## What

Type-only additions to `src/agent.ts`:

- `InternalToolCall` — `{ toolCallId, name, input }`
- `UseInternalToolAction` — emitted by the native app when the LLM picked an internal tool; engine pauses, emits reasoning events, then asks the app to execute it
- `ExecuteInternalToolParams` — engine → app: please execute this internal tool now
- `InternalToolResultAction` — app → engine: here's the result (SUCCESS / ERROR)
- `Action` widened to include the two new variants
- `PreviousActionResult.previousAction` widened to `UseToolAction | UseInternalToolAction`
- `NextActionParams` widened to include `ExecuteInternalToolParams`

No runtime behavior; this only adds discriminated-union variants. Existing consumers that only handle `UseToolAction` / `FinishAction` continue to type-check against the wider union via exhaustiveness checks where they exist.

## Deployment order

This PR is **step 1**. It must publish a new `@integromat/proto` version before any of the downstream PRs can be merged, because they import the new types:

1. **imt-proto** (this PR) — publish new minor version
2. **make-core** + **mono** ai-local-agent — bump proto dep, deploy together (engine emits new actions; native app handles `executeInternalToolParams`)
3. **make-ai-agents-api** — ships the new `/v1/agents/run/internal-tool` endpoint and gates the handoff behind feature flag `internal-tool-handoff-enabled` (default off)
4. **imt-inspector** — renders the new `useInternalToolAction` reasoning event
5. Turn on `internal-tool-handoff-enabled` in GrowthBook per zone/org

Steps 2–4 only become observable to users once step 5 happens, so they can roll out independently in any order between themselves.

## Test plan

- [ ] Unit tests still pass (`npm test`)
- [ ] After publish, downstream PRs install the new version and type-check clean
