### PR TITLE
feat: add nested-agent flags to AgentResources (WM-4231)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.13.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.13.0",
+      "version": "2.15.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.14.0",
+  "version": "2.15.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -13,6 +13,16 @@ export type AgentResources = {
       }>
     >
   >;
+  /**
+   * Nested-agent flags derived by the engine from the blueprint structure.
+   * The AI agents backend cannot tell root and nested agent runs apart from the
+   * ISC context alone, so the engine computes them and passes them alongside the
+   * resources. Grouped under `flags` to keep them out of the resources root.
+   */
+  flags: Readonly<{
+    hasNestedAgents: boolean;
+    isNestedAgent: boolean;
+  }>;
 };
 
 export type AgentContext = Readonly<Record<string, any>>;


### PR DESCRIPTION
## Motivation

Part of [WM-4231](https://make.atlassian.net/browse/WM-4231) (nested-agent error monitoring in Datadog). The engine is the only place that knows whether a local-agent run is nested (it has the blueprint + parentRoute); the AI agents backend cannot derive this from the ISC context alone. To pass that signal cleanly, `AgentResources` gains a first-class `flags` property.

Previously the consuming PRs bolted the flags on with local type extensions (`NestedAgentAwareResources` in make-core, an `AgentResources & NestedAgentFlags` intersection in mono). Per review feedback, this moves the flags into the shared proto type instead, grouped under a nested `flags` property so they don't sit at the resources root.

## Notes

- Adds `flags: Readonly<{ hasNestedAgents: boolean; isNestedAgent: boolean }>` to `AgentResources`.
- Bumps to `2.15.0`.
- Consumers bump to `2.15.0` once this publishes: make-core#958, mono#5594. agents-api#1327 is unaffected (its run-body schema is separate from AgentResources).

### Publish
On merge, push tag `2.15.0` to trigger the NPM publish workflow (or run it via workflow_dispatch).

[WM-4231]: https://make.atlassian.net/browse/WM-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ