### PR TITLE
feat(endpoint): add IMTEndpoint standalone proto class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Every node type in a Make scenario (triggers, actions, transformers, etc.) must 
 - `IMTRPC` (EventEmitter) — dynamic data lookup; override `execute(done)`
 - `IMTHook` (EventEmitter) — webhook handler; override `parse(request, done)`
 - `IMTAccount` / `IMTOAuthAccount` (no EventEmitter) — connection auth; OAuth subclass adds full auth flow
+- `IMTEndpoint` (EventEmitter) — Endpoints' base class; override `execute(input, done)`. Replaces the
+  compiled-as-`IMTRPC` shortcut Endpoints used previously — `instanceof IMTRPC` is deliberately `false`
 
 **Key patterns**:
 
@@ -65,7 +67,7 @@ Every node type in a Make scenario (triggers, actions, transformers, etc.) must 
 
 ## How
 
-Source in `src/` (flat, 24 files). Tests in `test/` (flat, 6 files). Build output in `dist/` (not in git).
+Source in `src/` (flat, 25 files). Tests in `test/` (flat, 8 files). Build output in `dist/` (not in git).
 
 **Build**: `npm run build` — runs `tsc --build tsconfig.lib.json` (clean + rebuild). Uses `tsconfig.lib.json` for library output only (excludes specs).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.15.0",
+  "version": "2.16.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,0 +1,109 @@
+import * as util from 'util';
+import { Warning } from './warning';
+import { EventEmitter } from 'events';
+import { CommonData, EnvironmentData, InternalData } from './base';
+import { DoneCallback, DoneWithResultCallback } from './types';
+
+export type EndpointInput = Record<string, any>;
+export type EndpointConnection = Record<string, any>;
+export type EndpointParameters = Record<string, any>;
+
+/**
+ * Base class for Endpoints.
+ *
+ * Endpoints are single-API-call wrappers and are fully standalone — a sibling of IMTRPC/IMTHook,
+ * not an IMTBase subclass. `instanceof IMTRPC` is deliberately `false` for instances of this class.
+ *
+ * @property {Object} common Collection of common parameters. Read only.
+ * @property {Object} parameters Collection of config parameters. Read only.
+ * @property {Object} connection Collection of connection parameters. Read only.
+ * @property {Object} environment Collection of environment parameters. Read only.
+ */
+
+export class IMTEndpoint extends EventEmitter {
+  // Field initializers rather than IMTRPC's explicit null-assigning constructor, matching the newer
+  // IMTBase style. Safe under the CoffeeScript/.inherits legacy tests because target: ES5 compiles
+  // classes to functions.
+  public common: CommonData | null = null;
+  // Typed as EndpointParameters (Record<string, any>), not `Parameters` from ./base: that type
+  // requires `host: string`, which no endpoint host has ever set.
+  public parameters: EndpointParameters | null = null;
+  public connection: EndpointConnection | null = null;
+  public environment: EnvironmentData | null = null;
+  public internal: InternalData | null = null;
+
+  /**
+   * Initializes the endpoint. Function that overrides should always call super.
+   *
+   * @callback done Callback to call when endpoint is initialized.
+   *     @param {Error} err Error on error, otherwise null.
+   */
+
+  initialize(done: DoneCallback): void {
+    if ('function' === typeof done) done();
+  }
+
+  /**
+   * Executes the endpoint.
+   *
+   * @param {Object} input Endpoint input.
+   * @callback done Callback to call when endpoint is done.
+   *     @param {Error} err Error on error, otherwise null.
+   *     @param {Object} result Endpoint result.
+   */
+
+  execute(input: EndpointInput, done: DoneWithResultCallback): void {
+    void input;
+    void done;
+    throw new Error("Must override a superclass method 'execute'.");
+  }
+
+  /**
+   * Finalizes the endpoint. Function that overrides should always call super.
+   *
+   * @callback done Callback to call when endpoint is finalized.
+   *     @param {Error} err Error on error, otherwise null.
+   */
+
+  finalize(done: DoneCallback): void {
+    if ('function' === typeof done) done();
+  }
+
+  /**
+   * Print debug message to Scenario info log. Debug messages are only visible to system administrators.
+   *
+   * @param {...*} message Message to be printed to Scenario info log.
+   */
+
+  debug(...args: any[]): void {
+    this.emit('debug', Array.prototype.slice.call(args));
+  }
+
+  /**
+   * Print message to Scenario info log.
+   *
+   * @param {...String|Warning|Error} message Message to be printed to Scenario info log.
+   */
+
+  log(...args: any[]): void {
+    if (args[0] instanceof Warning || args[0] instanceof Error) {
+      this.emit('log', args[0]);
+    } else {
+      this.emit('log', util.format(...args));
+    }
+  }
+
+  /**
+   * Print message to Scenario warning log.
+   *
+   * @param {...String|Warning|Error} message Message to be printed to Scenario warning log.
+   */
+
+  warn(...args: any[]): void {
+    if (args[0] instanceof Warning || args[0] instanceof Error) {
+      this.emit('warn', args[0]);
+    } else {
+      this.emit('warn', util.format(...args));
+    }
+  }
+}

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,6 +1,6 @@
-import * as util from 'util';
+import * as util from 'node:util';
 import { Warning } from './warning';
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { CommonData, EnvironmentData, InternalData } from './base';
 import { DoneCallback, DoneWithResultCallback } from './types';
 
@@ -53,8 +53,6 @@ export class IMTEndpoint extends EventEmitter {
    */
 
   execute(input: EndpointInput, done: DoneWithResultCallback): void {
-    void input;
-    void done;
     throw new Error("Must override a superclass method 'execute'.");
   }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -49,6 +49,7 @@ declare global {
   var IMTStarter: typeof publicApi.IMTStarter;
   var IMTAgent: typeof publicApi.IMTAgent;
   var IMTConditional: typeof publicApi.IMTConditional;
+  var IMTEndpoint: typeof publicApi.IMTEndpoint;
 }
 
 if (!global.IMT_PROTO_LOADED) {
@@ -104,4 +105,5 @@ if (!global.IMT_PROTO_LOADED) {
   global.IMTStarter = publicApi.IMTStarter;
   global.IMTAgent = publicApi.IMTAgent;
   global.IMTConditional = publicApi.IMTConditional;
+  global.IMTEndpoint = publicApi.IMTEndpoint;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export * from './returner';
 export * from './starter';
 export * from './agent';
 export * from './conditional';
+export * from './endpoint';

--- a/test/endpoint.spec.ts
+++ b/test/endpoint.spec.ts
@@ -1,0 +1,129 @@
+import * as assert from 'assert';
+import { IMTRPC } from '../src/rpc';
+import { DataError } from '../src/error';
+import { Warning } from '../src/warning';
+import { DoneWithResultCallback } from '../src/types';
+import { EndpointInput, IMTEndpoint } from '../src/endpoint';
+
+class TestEndpoint extends IMTEndpoint {
+  execute(input: EndpointInput, done: DoneWithResultCallback) {
+    if (input.number > 10) return done(new DataError('Number is greater than 10.'));
+
+    done(null, { result: input.number * 2 });
+  }
+}
+
+describe('IMTEndpoint', () => {
+  it('should operate successfully', (done) => {
+    const input = {
+      number: 1,
+    };
+
+    const endpoint = new TestEndpoint();
+    endpoint.initialize((err) => {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      endpoint.execute(input, (err, output) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        assert.ok(endpoint instanceof IMTEndpoint);
+        assert.ok(!(endpoint instanceof IMTRPC), 'Endpoint should not be an instance of IMTRPC.');
+        assert.strictEqual(output.result, 2, 'Result should be equal to 2.');
+
+        endpoint.finalize(done);
+      });
+    });
+  });
+
+  it('should fail with DataError', (done) => {
+    const input = {
+      number: 11,
+    };
+
+    const endpoint = new TestEndpoint();
+    endpoint.initialize((err) => {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      endpoint.execute(input, (err) => {
+        assert.ok(err, 'Execute should return error.');
+        assert.ok(err instanceof DataError, 'Error should be instanceof DataError.');
+
+        endpoint.finalize(done);
+      });
+    });
+  });
+
+  it('should throw when execute is not overridden', () => {
+    const endpoint = new IMTEndpoint();
+
+    assert.throws(() => endpoint.execute({}, () => undefined), /Must override a superclass method 'execute'\./);
+  });
+
+  describe('logging', () => {
+    it('should emit debug event with the arguments array', (done) => {
+      const endpoint = new IMTEndpoint();
+
+      endpoint.on('debug', (args) => {
+        assert.deepStrictEqual(args, ['debug message']);
+        done();
+      });
+
+      endpoint.debug('debug message');
+    });
+
+    it('should emit log event with a formatted string', (done) => {
+      const endpoint = new IMTEndpoint();
+
+      endpoint.on('log', (message) => {
+        assert.strictEqual(message, 'log message');
+        done();
+      });
+
+      endpoint.log('log message');
+    });
+
+    it('should emit log event with the Warning instance verbatim', (done) => {
+      const endpoint = new IMTEndpoint();
+      const warning = new Warning('log warning');
+
+      endpoint.on('log', (message) => {
+        assert.strictEqual(message, warning);
+        done();
+      });
+
+      endpoint.log(warning);
+    });
+
+    it('should emit warn event with a formatted string', (done) => {
+      const endpoint = new IMTEndpoint();
+
+      endpoint.on('warn', (message) => {
+        assert.strictEqual(message, 'warn message');
+        done();
+      });
+
+      endpoint.warn('warn message');
+    });
+
+    it('should emit warn event with the Warning instance verbatim', (done) => {
+      const endpoint = new IMTEndpoint();
+      const warning = new Warning('warn warning');
+
+      endpoint.on('warn', (message) => {
+        assert.strictEqual(message, warning);
+        done();
+      });
+
+      endpoint.warn(warning);
+    });
+  });
+});

--- a/test/legacy-compatibility.test.ts
+++ b/test/legacy-compatibility.test.ts
@@ -24,6 +24,7 @@ describe('Legacy Compatibility', () => {
     IMTStarter,
     IMTAgent,
     IMTConditional,
+    IMTEndpoint,
   ];
 
   it('exports global variables', () => {
@@ -74,6 +75,7 @@ describe('Legacy Compatibility', () => {
     expect(global.IMTStarter).toBeDefined();
     expect(global.IMTAgent).toBeDefined();
     expect(global.IMTConditional).toBeDefined();
+    expect(global.IMTEndpoint).toBeDefined();
   });
 
   it('should have same values for globals and for public API', () => {
@@ -119,6 +121,7 @@ describe('Legacy Compatibility', () => {
     expect(global.IMTStarter === publicApi.IMTStarter).toBe(true);
     expect(global.IMTAgent === publicApi.IMTAgent).toBe(true);
     expect(global.IMTConditional === publicApi.IMTConditional).toBe(true);
+    expect(global.IMTEndpoint === publicApi.IMTEndpoint).toBe(true);
   });
 
   it('should be compatible with CoffeeScript classes', () => {


### PR DESCRIPTION
https://make.atlassian.net/browse/SPEED-853

## WHY

The Endpoints RFC compiles Endpoints as `IMTRPC` subclasses as a deliberate shortcut; the Executor RFC calls for a proper `IMTEndpoint` class so Endpoints stop being compiled as RPCs. `imt-proto` is the source of all proto base classes, so the class lands here first.

## WHAT

- Adds `IMTEndpoint` (`src/endpoint.ts`): a standalone `EventEmitter`, a sibling of `IMTRPC`/`IMTHook` rather than an `IMTBase` subclass. Ships `execute(input, done)`, a declared `connection` property (replacing the `__IMTCONN__` parameter hack), and real `debug`/`log`/`warn` emitters matching `IMTBase`'s behavior.
- Wires the class into `src/index.ts` and `src/global.ts` (legacy global export), and adds it to the generic inheritance suites in `test/legacy-compatibility.test.ts`.
- New `test/endpoint.spec.ts`: full lifecycle, `DataError` path, abstract-method throw, emitter behavior (including `Warning`/`Error` passthrough), and the `instanceof IMTRPC === false` check.
- Version bump `2.15.0` → `2.16.0` (additive minor).

## REASONING

Modeled on `src/rpc.ts` for structure and `IMTBase` for emitter bodies. Fully standalone rather than an `IMTRPC` subclass — `instanceof IMTRPC` is deliberately `false` — so runtimes can dispatch on the real class instead of the RPC shortcut. Nothing in this repo consumes `IMTEndpoint` yet; this is purely additive.

## RISK ESTIMATION

Low. No existing classes or exports are touched (`base.ts` is untouched); all changes are append-only. Verified with a clean build, full test suite (31/31 passing), lint, Prettier, and manual smoke tests of both package entry points confirming the class loads and the `instanceof IMTRPC` break holds. Coordinated follow-ups in other repos (`imt-web-api`, `make-core`, `imt-app-runtime`, `make-apps-processor`) are tracked separately and must land, in order, before any apps are recompiled — that risk lives in those repos, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)