### PR TITLE
fix(endpoint): remove listeners on finalize, cover Error passthrough

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -64,6 +64,7 @@ export class IMTEndpoint extends EventEmitter {
    */
 
   finalize(done: DoneCallback): void {
+    this.removeAllListeners();
     if ('function' === typeof done) done();
   }
 

--- a/test/endpoint.spec.ts
+++ b/test/endpoint.spec.ts
@@ -68,6 +68,17 @@ describe('IMTEndpoint', () => {
     assert.throws(() => endpoint.execute({}, () => undefined), /Must override a superclass method 'execute'\./);
   });
 
+  it('should remove all listeners on finalize', (done) => {
+    const endpoint = new IMTEndpoint();
+    endpoint.on('log', () => undefined);
+    assert.strictEqual(endpoint.listenerCount('log'), 1);
+
+    endpoint.finalize(() => {
+      assert.strictEqual(endpoint.listenerCount('log'), 0);
+      done();
+    });
+  });
+
   describe('logging', () => {
     it('should emit debug event with the arguments array', (done) => {
       const endpoint = new IMTEndpoint();
@@ -124,6 +135,30 @@ describe('IMTEndpoint', () => {
       });
 
       endpoint.warn(warning);
+    });
+
+    it('should emit log event with an Error instance verbatim', (done) => {
+      const endpoint = new IMTEndpoint();
+      const error = new Error('log error');
+
+      endpoint.on('log', (message) => {
+        assert.strictEqual(message, error);
+        done();
+      });
+
+      endpoint.log(error);
+    });
+
+    it('should emit warn event with an Error instance verbatim', (done) => {
+      const endpoint = new IMTEndpoint();
+      const error = new Error('warn error');
+
+      endpoint.on('warn', (message) => {
+        assert.strictEqual(message, error);
+        done();
+      });
+
+      endpoint.warn(error);
     });
   });
 });


### PR DESCRIPTION
https://make.atlassian.net/browse/BAR-3403

## WHY

PR #60 (`IMTEndpoint`) was approved with "LGTM, but please check the Copilot suggestions before merging" and got merged before those suggestions were addressed. This PR resolves them.

## WHAT

- `finalize()` now calls `this.removeAllListeners()` before invoking `done()`, matching `IMTBase.finalize()`'s lifecycle behavior.
- Adds a test asserting listeners are cleared on `finalize()`.
- Adds the missing `Error`-passthrough test cases for `log()`/`warn()` (only the `Warning` branch was previously covered).

## REASONING

`IMTEndpoint.finalize()` was modeled on `IMTRPC.finalize()`, which never clears listeners — but the emitter *behavior* (`debug`/`log`/`warn`) was explicitly modeled on `IMTBase`, which does call `removeAllListeners()` in `finalize()`. Without it, `debug`/`log`/`warn` listeners accumulate across executions on a reused or long-lived endpoint instance. The `log()`/`warn()` gap is a pure test-coverage fix: the implementation already branches on `instanceof Warning || instanceof Error`, but only `Warning` had a test locking in the passthrough (vs. formatted-string) behavior.

## RISK ESTIMATION

Low. Two-file, 36-line diff, additive/test-only aside from the one-line `finalize()` change. No public API or exported types change. Verified: clean build, full test suite (34/34 passing, 3 new), lint, and Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)