### PR TITLE
chore: bump version to 2.17.0 (WM-4273)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integromat/proto",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integromat/proto",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integromat",
     "imt"
   ],
-  "version": "2.16.0",
+  "version": "2.17.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
[Has Ai Code]

https://make.atlassian.net/browse/WM-4273

### Notes

Bumps `@integromat/proto` to 2.17.0. Version only, no code change.

2.16.0 is already published to npm (2026-07-29 09:03, manual `workflow_dispatch` on 889795b). That tarball contains the `IMTEndpoint` work from #60/#62 but **not** the `contextWindow` field from #61.

#61 also carried a 2.15.0 → 2.16.0 bump, but master had already been bumped to 2.16.0 by #60, so the bump was a no-op against master's tip and git merged it silently. The squash commit `aacae49` landed `src/agent.ts` only.

Net effect on master today: `package.json` says 2.16.0 while the tree contains a field the published 2.16.0 does not have. Consumers resolving `@integromat/proto@2.16.0` get a build without `contextWindow`, and the next publish dispatch would be rejected by npm for republishing an existing version.

2.17.0 gives `contextWindow` a version that can actually be published.

**Risk:** none beyond the version string. `src/` untouched.

### Follow-up

Needs a `workflow_dispatch` of NPM Publish on master after merge, so the WM-4273 consumers (mono#5808, make-core#1101, imt-inspector#2865) have a real version to bump onto.
